### PR TITLE
Update link to BitBay API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BitBay REST API for Python3
-See full description at https://docs.bitbay.net/v1.0.1-en/reference
+See full description at https://docs.bitbay.net/v1.0.2-en/reference
 
 ## Update History
 0.1.2 - add webscoket implementations


### PR DESCRIPTION
The current link leads to a 404 error. Should be updated to version 1.0.2.